### PR TITLE
Fix to #1 - use JSON.generate

### DIFF
--- a/lib/ro-bundle/ro/agent.rb
+++ b/lib/ro-bundle/ro/agent.rb
@@ -65,7 +65,7 @@ module ROBundle
     # Write this Agent out as a json string. Takes the same options as
     # JSON#generate.
     def to_json(*a)
-      Util.clean_json(@structure).to_json(*a)
+      JSON.generate(Util.clean_json(@structure),*a)
     end
 
   end

--- a/lib/ro-bundle/ro/aggregate.rb
+++ b/lib/ro-bundle/ro/aggregate.rb
@@ -83,7 +83,7 @@ module ROBundle
     # Write this Aggregate out as a json string. Takes the same options as
     # JSON#generate.
     def to_json(*a)
-      Util.clean_json(@structure).to_json(*a)
+      JSON.generate(Util.clean_json(@structure),*a)
     end
 
     # :stopdoc:

--- a/lib/ro-bundle/ro/annotation.rb
+++ b/lib/ro-bundle/ro/annotation.rb
@@ -119,7 +119,7 @@ module ROBundle
     def to_json(*a)
       cleaned = Util.clean_json(@structure)
       cleaned[:about] = target
-      cleaned.to_json(*a)
+      JSON.generate(cleaned,*a)
     end
 
   end

--- a/lib/ro-bundle/ro/manifest.rb
+++ b/lib/ro-bundle/ro/manifest.rb
@@ -240,7 +240,7 @@ module ROBundle
     # Write this Manifest out as a json string. Takes the same options as
     # JSON#generate.
     def to_json(*a)
-      Util.clean_json(structure).to_json(*a)
+      JSON.generate(Util.clean_json(structure),*a)
     end
 
     # :call-seq:

--- a/lib/ro-bundle/ro/proxy.rb
+++ b/lib/ro-bundle/ro/proxy.rb
@@ -65,7 +65,7 @@ module ROBundle
     # Write this Proxy out as a json string. Takes the same options as
     # JSON#generate.
     def to_json(*a)
-      Util.clean_json(@structure).to_json(*a)
+      JSON.generate(Util.clean_json(@structure),*a)
     end
 
     private


### PR DESCRIPTION
use JSON.generate rather than .to_json(*a) for json generation. This avoids
a conflict with ActiveSupport core extension, which provides its own to_json, and appears to behave differently.
One important difference that was causing this problem, was that it didn't seem to delegate on to a to_json method within
a nested object.
